### PR TITLE
[COOK-1124] parameterised driftfile and statsdir to be configurable by ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs and configures ntp, optionally set up a local NTP server.
 Requirements
 ============
 
-Should work on any Red Hat-family or Debian-family Linux distribution.
+Should work on any Red Hat-family or Debian-family Linux distribution or on FreeBSD.
 
 Attributes
 ==========
@@ -33,12 +33,21 @@ Attributes
   - Array, should be a list of restrict lines to restrict access to NTP
     clients on your LAN.
 
-USAGE
+* ntp[:driftfile]
+
+  - String, the path to the frequency file.
+
+* ntp[:statsdir]
+
+  - String, the directory path for files created by the statistics facility.
+
+Usage
 =====
 
 Set up the ntp attributes in a role. For example in a base.rb role applied to all nodes:
 
     name "base"
+    description "Role applied to all systems"
     default_attributes(
       "ntp" => {
         "servers" => ["time0.int.example.org", "time1.int.example.org"]
@@ -47,19 +56,20 @@ Set up the ntp attributes in a role. For example in a base.rb role applied to al
 
 Then in an ntpserver.rb role that is applied to NTP servers (e.g., time.int.example.org):
 
-    name "base"
+    name "ntp_server"
+    description "Role applied to the system that should be an NTP server."
     default_attributes(
       "ntp" => {
         "is_server" => "true",
-        "servers" => ["0.pool.ntp.org", "1.pool.ntp.org"]
-        "peers" => ["time0.int.example.org", "time1.int.example.org"]
+        "servers" => ["0.pool.ntp.org", "1.pool.ntp.org"],
+        "peers" => ["time0.int.example.org", "time1.int.example.org"],
         "restrictions" => ["10.0.0.0 mask 255.0.0.0 nomodify notrap"]
       }
     )
 
 The timeX.int.example.org used in these roles should be the names or IP addresses of internal NTP servers.
 
-LICENSE AND AUTHOR
+License and Author
 ==================
 
 Author:: Joshua Timberman (<joshua@opscode.com>)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,19 +1,41 @@
-case platform 
+#
+# Cookbook Name:: ntp
+# Attributes:: default
+#
+# Author:: Joshua Timberman (<joshua@opscode.com>)
+#
+# Copyright 2009-2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# default attributes for all platforms
+default[:ntp][:is_server] = false
+default[:ntp][:servers]   = ["0.pool.ntp.org", "1.pool.ntp.org"]
+default[:ntp][:driftfile] = "/var/lib/ntp/ntp.drift"
+default[:ntp][:statsdir] = "/var/log/ntpstats/"
+
+# overrides on a platform-by-platform basis
+case platform
 when "ubuntu","debian"
   default[:ntp][:service] = "ntp"
-  default[:ntp][:root_group] = "root"
 when "redhat","centos","fedora","scientific"
   default[:ntp][:service] = "ntpd"
-  default[:ntp][:root_group] = "root"
 when "freebsd"
   default[:ntp][:service] = "ntpd"
-  default[:ntp][:root_group] = "wheel"
+  default[:ntp][:driftfile] = "/var/db/ntpd.drift"
+  default[:ntp][:statsdir] = "/var/db/ntpstats/"
 else
   default[:ntp][:service] = "ntpd"
-  default[:ntp][:root_group] = "root"
 end
 
-default[:ntp][:is_server] = false
-default[:ntp][:servers]   = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
-default[:ntp][:peers] = []
-default[:ntp][:restrictions] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version           "1.1.2"
 
 recipe "ntp", "Installs and configures ntp either as a server or client"
 
-%w{ ubuntu debian redhat centos fedora scientific }.each do |os|
+%w{ ubuntu debian redhat centos fedora scientific freebsd }.each do |os|
   supports os
 end
 
@@ -43,3 +43,13 @@ attribute "ntp/restrictions",
   :description => "Array of restriction lines to apply to NTP servers",
   :type => "array",
   :default => []
+
+attribute "ntp/driftfile",
+  :display_name => "NTP Driftfile",
+  :description => "Location of the NTP driftfile",
+  :default => "/var/lib/ntp/ntp.drift"
+
+attribute "ntp/statsdir",
+  :display_name => "NTP Statsdir",
+  :description => "Location of the NTP statsdir",
+  :default => "/var/log/ntpstats/"

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -4,8 +4,8 @@
 <% if node[:virtualization][:role] == "guest" -%>
 tinker panic 0
 <% end -%>
-driftfile /var/lib/ntp/ntp.drift
-statsdir /var/log/ntpstats/
+driftfile <%= node[:ntp][:driftfile] %>
+statsdir <%= node[:ntp][:statsdir] %>
 
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable
@@ -41,7 +41,7 @@ restrict <%= restriction %>
   <% end -%>
 <% end -%>
 
-<%# It is best practice to use an high stratum undisciplined clock, if you have a real CMOS clock -%>
+<%# It is best practice to use a high stratum undisciplined clock, if you have a real CMOS clock -%>
 <%# Except cases where you have a low stratum server, or a virtualized system without a real CMOS clock -%>
 <% if ! node[:ntp][:is_server] and node[:virtualization][:role] != "guest" -%>
 server  127.127.1.0 # local clock


### PR DESCRIPTION
...platform

Parameterised the "driftfile" and "statsdir" configurables in ntp.conf, so that they could be platform agnostic.
Also made some fixups in the README.
