### PR TITLE
Remove trailing comma, otherwise upload fails with "FATAL: Cookbook file...

### DIFF
--- a/recipes/disable.rb
+++ b/recipes/disable.rb
@@ -16,7 +16,7 @@ when "ubuntu","debian"
 		group root_group
 		mode "0644"
 		variables(
-			:disable => TRUE,
+			:disable => TRUE
 		)
 	end
 end


### PR DESCRIPTION
... recipes/disable.rb has a ruby syntax error:

FATAL: /Users/jdunn/devel/git/sop/sm-chef/cookbooks/ntp/recipes/disable.rb:20: syntax error, unexpected ')'"
