### PR TITLE
Updated 'debian' (only) to reflect multi-Linux + FreeBSD reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Description
 
-Installs and configures ntp, optionally configure ntpdate on debian family platforms.
+Installs and configures ntp and optionally configures ntpdate on Red Hat-family
+and Debian-family Linux distributions, or FreeBSD family platforms.
 
 ### About the refactor
 


### PR DESCRIPTION
One intro line (probably old) indicated "...for debian" yet further
down the reality of RHEL/CentOS, Debian, Ubuntu, FreeBSD was indicated.
Updated the former line.

Fixes http://tickets.opscode.com/browse/COOK-1672
