### PR TITLE
Escape Markdown syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ Should work on Red Hat-family and Debian-family Linux distributions, or FreeBSD.
 
 ## Recommended tunables
 
-* ntp['servers'] (applies to NTP Servers and Clients)
+* ntp['servers'] \(applies to NTP Servers and Clients)
 
   - Array, should be a list of upstream NTP public servers.  The NTP protocol
     works best with at least 3 servers.  The NTPD maximum is 7 upstream
     servers, any more than that and some of them will be ignored by the daemon.
 
-* ntp['peers'] (applies to NTP Servers ONLY)
+* ntp['peers'] \(applies to NTP Servers ONLY)
 
   - Array, should be a list of local NTP private servers.  Configuring peer
     servers on your LAN will reduce traffic to upstream time sources, and
     provide higher availability of NTP on your LAN.  Again the maximum is 7
     peers
 
-* ntp['restrictions'] (applies to NTP Servers only)
+* ntp['restrictions'] \(applies to NTP Servers only)
 
   - Array, should be a list of restrict lines to restrict access to NTP
     clients on your LAN.


### PR DESCRIPTION
Use a backslash escape before parentheses where they follow square brackets so that Markdown does not convert them to links.
