### PR TITLE
COOK-2795 -- Update README.md re: ntpd docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,79 +6,89 @@ Installs and configures ntp, optionally configure ntpdate on debian family platf
 
 ### About the refactor
 
-This recipe was heavily re-factored as a Hackday exercise at Chefconf 2012.
-The purpose of refactoring was to have a simple community cookbook which
-serves as a testing documentation reference.  We chose a lightweight testing method
-using minitest to validate the sanity of our default attributes.
+This recipe was heavily re-factored as a Hackday exercise at Chefconf
+2012.  The purpose of refactoring was to have a simple community
+cookbook which serves as a testing documentation reference.  We
+chose a lightweight testing method using minitest to validate the
+sanity of our default attributes.
 
-More information on our testing strategy used in this cookbook is available
-in the TESTING.  Along with information on how to use this type of lightweight
-testing in your own cookbooks.
+More information on our testing strategy used in this cookbook is
+available in the TESTING.  Along with information on how to use
+this type of lightweight testing in your own cookbooks.
 
 #### IMPORTANT NOTES
 
-Breaking changes are the absence of an ntp::disable recipe.  This was factored
-out into an ntp::undo corresponding to the default recipe and a separate
-ntp::ntpdate recipe.
+Breaking changes are the absence of an ntp::disable recipe.  This
+was factored out into an ntp::undo corresponding to the default
+recipe and a separate ntp::ntpdate recipe.
 
-The ntp::undo recipe stops and removes ntp components.  The ntp::ntpdate
-recipe configures the ntpdate component.  The ntp['ntpdate']['disable'] boolean
-will disable the ntpdate-debian command on Debian family distributions.
+The ntp::undo recipe stops and removes ntp components.  The
+ntp::ntpdate recipe configures the ntpdate component.  The
+ntp['ntpdate']['disable'] boolean will disable the ntpdate-debian
+command on Debian family distributions.
 
 ## Requirements
 
-Should work on Red Hat-family and Debian-family Linux distributions, or FreeBSD.
+Should work on Red Hat-family and Debian-family Linux distributions,
+or FreeBSD.
 
 # Attributes
 
 ## Recommended tunables
 
-* ntp['servers'] (applies to NTP Servers and Clients)
+* ntp['servers'] -- applies to NTP Servers and Clients
 
-  - Array, should be a list of upstream NTP public servers.  The NTP protocol
-    works best with at least 3 servers.  The NTPD maximum is 7 upstream
-    servers, any more than that and some of them will be ignored by the daemon.
+    - Array, should be a list of upstream NTP public servers.  The
+      NTP protocol works best with at least 4 servers, in order to
+      deal with the possibility of "falsetickers".  The NTP daemon
+      can monitor hundreds of upstream time servers, but by default
+      it won't attempt to actually use more than ten of them.
+      Anything beyond ten will be monitored but will not be mobilized.
 
-* ntp['peers'] (applies to NTP Servers ONLY)
+    - More information on this issue can be found at
+  <http://support.ntp.org/bin/view/Support/SelectingOffsiteNTPServers#Section_5.3.3.>
 
-  - Array, should be a list of local NTP private servers.  Configuring peer
-    servers on your LAN will reduce traffic to upstream time sources, and
-    provide higher availability of NTP on your LAN.  Again the maximum is 7
-    peers
+* ntp['peers'] -- applies to NTP Servers ONLY
 
-* ntp['restrictions'] (applies to NTP Servers only)
+    - Array, should be a list of local NTP private servers.
+      Configuring peer servers on your LAN will reduce traffic to
+      upstream time sources, and provide higher availability of NTP
+      on your LAN.  See above for the recommended minimum and maximum
+      number of upstream time servers.
 
-  - Array, should be a list of restrict lines to restrict access to NTP
-    clients on your LAN.
+* ntp['restrictions'] -- applies to NTP Servers ONLY
+
+    - Array, should be a list of restrict lines to restrict access to NTP
+      clients on your LAN.
 
 * ntp['ntpdate']['disable']
 
-  - Boolean, disables the use of ntpdate-debian if set to true.
-  - Defaults to false, and will not disable ntpdate.  There is usually no
-    init service to manage with ntpdate.  Therefore it should not conflict
-    with ntpd in most cases.
+    - Boolean, disables the use of ntpdate-debian if set to true.
+    - Defaults to false, and will not disable ntpdate.  There is usually no
+      init service to manage with ntpdate.  Therefore it should not conflict
+      with ntpd in most cases.
 
 ## Platform specific
 
 * ntp['packages']
 
-  - Array, the packages to install
-  - Default, ntp for everything, ntpdate depending on platform
+    - Array, the packages to install
+    - Default, ntp for everything, ntpdate depending on platform
 
 * ntp['service']
 
-  - String, the service to act on
-  - Default, ntp or ntpd, depending on platform
+    - String, the service to act on
+    - Default, ntp or ntpd, depending on platform
 
 * ntp['driftfile']
 
-  - String, the path to the frequency file.
-  - Default, platform-specific location.
+    - String, the path to the frequency file.
+    - Default, platform-specific location.
 
 * ntp['varlibdir']
 
-  - String, the path to /var/lib files such as the driftfile.
-  - Default, platform-specific location.
+    - String, the path to /var/lib files such as the driftfile.
+    - Default, platform-specific location.
 
 * ntp['statsdir']
 
@@ -87,13 +97,13 @@ Should work on Red Hat-family and Debian-family Linux distributions, or FreeBSD.
 
 * ntp['conf\_owner'] and ntp['conf\_group']
 
-  - String, the owner and group of the sysconf directory files, such as /etc/ntp.conf.
-  - Default, platform-specific root:root or root:wheel
+    - String, the owner and group of the sysconf directory files, such as /etc/ntp.conf.
+    - Default, platform-specific root:root or root:wheel
 
 * ntp['var\_owner'] and ntp['var\_group']
 
-  - String, the owner and group of the /var/lib directory files, such as /var/lib/ntp.
-  - Default, platform-specific ntp:ntp or root:wheel
+    - String, the owner and group of the /var/lib directory files, such as /var/lib/ntp.
+    - Default, platform-specific ntp:ntp or root:wheel
 
 ## Usage
 
@@ -105,7 +115,7 @@ Set up the ntp attributes in a role. For example in a base.rb role applied to al
     description "Role applied to all systems"
     default_attributes(
       "ntp" => {
-        "servers" => ["time0.int.example.org", "time1.int.example.org"]
+        "servers" => ["time0.int.example.org"]
       }
     )
 
@@ -145,10 +155,12 @@ ntp::undo to your run\_list.
 Author:: Joshua Timberman (<joshua@opscode.com>)
 Contributor:: Eric G. Wolfe (<wolfe21@marshall.edu>)
 Contributor:: Fletcher Nichol (<fletcher@nichol.ca>)
+Contributor:: Brad Knowles (<bknowles@momentumsi.com>)
 
 Copyright 2009-2011, Opscode, Inc.
 Copyright 2012, Eric G. Wolfe
 Copyright 2012, Fletcher Nichol
+Copyright 2013, Brad Knowles
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Needed to update cookbook documentation to correct information regarding minimum and maximum number of upstream time servers, based on latest information at http://support.ntp.org/bin/view/Support/SelectingOffsiteNTPServers#Section_5.3.3..
