### PR TITLE
Apparmor disabling NTP because of missing line in ntp apparmor config file for leapseconds

### DIFF
--- a/files/default/usr.sbin.ntpd
+++ b/files/default/usr.sbin.ntpd
@@ -1,0 +1,82 @@
+# vim:syntax=apparmor
+# Updated for Ubuntu by: Jamie Strandboge <jamie@canonical.com>
+# ------------------------------------------------------------------
+#
+#    Copyright (C) 2002-2005 Novell/SUSE
+#    Copyright (C) 2009-2012 Canonical Ltd.
+#
+#    This program is free software; you can redistribute it and/or
+#    modify it under the terms of version 2 of the GNU General Public
+#    License published by the Free Software Foundation.
+#
+# ------------------------------------------------------------------
+# written by Chef
+
+#include <tunables/global>
+#include <tunables/ntpd>
+/usr/sbin/ntpd {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/user-tmp>
+
+  capability ipc_lock,
+  capability net_bind_service,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  capability sys_resource,
+  capability sys_time,
+  capability sys_nice,
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+
+  @{PROC}/net/if_inet6 r,
+  @{PROC}/*/net/if_inet6 r,
+  @{NTPD_DEVICE} rw,
+
+  /usr/sbin/ntpd rmix,
+
+  /etc/ntp.conf r,
+  /etc/ntp.conf.dhcp r,
+  /etc/ntpd.conf r,
+  /etc/ntpd.conf.tmp r,
+/var/lib/ntp/ntp.conf.dhcp r,
+
+  /etc/ntp.keys r,
+  /etc/ntp/** r,
+
+  /etc/ntp.drift rwl,
+  /etc/ntp.drift.TEMP rwl,
+  /etc/ntp/drift* rwl,
+  /var/lib/ntp/*drift rw,
+  /var/lib/ntp/*drift.TEMP rw,
+
+  /var/log/ntp w,
+  /var/log/ntp.log w,
+  /var/log/ntpd w,
+  /var/log/ntpstats/clockstats* rwl,
+  /var/log/ntpstats/loopstats*  rwl,
+  /var/log/ntpstats/peerstats*  rwl,
+  /var/log/ntpstats/rawstats*   rwl,
+  /var/log/ntpstats/sysstats*   rwl,
+
+  /{,var/}run/ntpd.pid w,
+
+  # samba4 ntp signing socket
+  /{,var/}run/samba/ntp_signd/socket rw,
+
+  # fix for apparmor
+  /etc/ntp.leapseconds r,
+
+  # For use with clocks that report via shared memory (e.g. gpsd),
+  # you may need to give ntpd access to all of shared memory, though
+  # this can be considered dangerous. See https://launchpad.net/bugs/722815
+  # for details. To enable, add this to local/usr.sbin.ntpd:
+  #     capability ipc_owner,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.sbin.ntpd>
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures ntp as a client or server"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.3.2"
+version           "1.3.3"
 
 recipe "ntp", "Installs and configures ntp either as a server or client"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,10 +35,21 @@ service node['ntp']['service'] do
   action [ :enable, :start ]
 end
 
+service "apparmor" do
+  action :nothing
+  supports [ :restart, :reload, :status ]
+end
+
 cookbook_file node['ntp']['leapfile'] do
   owner node['ntp']['conf_owner']
   group node['ntp']['conf_group']
   mode 0644
+end
+
+cookbook_file "/etc/apparmor.d/usr.sbin.ntpd" do
+  source "usr.sbin.ntpd"
+  mode "0644"
+  notifies :restart, resources(:service => "apparmor")
 end
 
 template "/etc/ntp.conf" do


### PR DESCRIPTION
This fix was added to deal with the issue where apparmor disables ntp:

[9789856.669346] type=1400 audit(1373675824.822:19): apparmor="DENIED" operation="open" parent=1 profile="/usr/sbin/ntpd" name="/etc/ntp.leapseconds" pid=1884 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
