### PR TITLE
COOK-3797 - Updated Chefignore file to ignore spec directory.

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -17,3 +17,4 @@
 */test/*
 \.travis.yml
 Rakefile
+*/spec/*


### PR DESCRIPTION
Resolve COOK-3797, Chefignore ignores spec directory.
