### PR TITLE
add check for existanse of node["virtualization"]

### DIFF
--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -3,7 +3,7 @@
 <%# Windows OHAI does not support determining if a host is a guest %>
 <% unless node['platform'] == 'windows' -%>
 <%# See http://www.vmware.com/vmtn/resources/238 p. 23 for explanation %>
-<%   if node['virtualization']['role'] == 'guest' -%>
+<%   if !node['virtualization'].nil? && node['virtualization']['role'] == 'guest' -%>
 <%  -%>tinker panic 0
 <%   end -%>
 <%-%>statsdir <%= node['ntp']['statsdir'] %>
@@ -62,7 +62,7 @@ restrict -6 ::1 nomodify
 <%# It is best practice to use a high stratum undisciplined clock, if you have a real CMOS clock %>
 <%# Except cases where you have a low stratum server, or a virtualized system without a real CMOS clock %>
 <% unless node['platform'] == 'windows' -%>
-<%   unless node['virtualization']['role'] == 'guest' -%>
+<%   unless !node['virtualization'].nil? && node['virtualization']['role'] == 'guest' -%>
 <%  -%>server  127.127.1.0 # local clock
 <%  -%>fudge   127.127.1.0 stratum 10
 <%   end -%>


### PR DESCRIPTION
Sometimes users need to disable some plugins in ohai, in my case
i need to disable virtualization plugin and recipe fails like:

Generated at 2013-12-13 10:34:19 +0400
Chef::Mixin::Template::TemplateError:

Chef::Mixin::Template::TemplateError (undefined method `[]' for nil:NilClass) on line #4:

  2: # Local modifications will be overwritten.
  3: <%# See http://www.vmware.com/vmtn/resources/238 p. 23 for explanation %>
  4: <% if node['virtualization']['role'] == "guest" -%>
  5: tinker panic 0
  6: <% end -%>

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
