### PR TITLE
[COOK-4339] Disable MONLIST by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['ntp']['sync_hw_clock'] = false
 default['ntp']['listen'] = nil
 default['ntp']['listen_network'] = nil
 default['ntp']['apparmor_enabled'] = false
+default['ntp']['monitor'] = false
 
 # overrides on a platform-by-platform basis
 case node['platform_family']

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -81,6 +81,10 @@ describe 'ntp attributes' do
     it 'sets apparmor_enabled to false' do
       expect(ntp['apparmor_enabled']).to eq(false)
     end
+
+    it 'sets monitor to false' do
+      expect(ntp['monitor']).to eq(false)
+    end
   end
 
   describe 'on Debian-family platforms' do

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -25,6 +25,12 @@ interface listen 127.0.0.1
   <% end -%>
 <% end -%>
 
+<% if node['ntp']['monitor'] -%>
+enable monitor
+<% else -%>
+disable monitor
+<% end -%>
+
 <%# If ntp.peers is not empty %>
 <% unless node['ntp']['peers'].empty? -%>
 <%   node['ntp']['peers'].each do |ntppeer| -%>


### PR DESCRIPTION
After the huge CloudFlare DDoS using ntp, they've published a followup:
http://blog.cloudflare.com/technical-details-behind-a-400gbps-ntp-amplification-ddos-attack

One of the things mentioned is to ensure MONLIST is disabled in your ntp
servers. While ntp may or may not be exposed for any given converge, it
may be appropriate to get this setting into the attribute/config and
have it disabled by default just in case: http://openntpproject.org/

https://tickets.opscode.com/browse/COOK-4339
