### PR TITLE
Ensure that ntp version is captured

### DIFF
--- a/libraries/ntp_helper.rb
+++ b/libraries/ntp_helper.rb
@@ -30,7 +30,7 @@ module Opscode
         if ntpd_version
           ntpd_version =~ /ntpd.*(\d+\.\d+\.\d+)/
           # Abuse of Gem::Requirement, but it works
-          Gem::Requirement.new('>= 4.2.6').satisfied_by?(Gem::Version.new(Regexp.last_match[1]))
+          Gem::Requirement.new('>= 4.2.6').satisfied_by?(Gem::Version.new(Regexp.last_match(1)))
         else
           false
         end
@@ -41,7 +41,7 @@ module Opscode
       def determine_ntpd_version
         cmd = shell_out!('ntpd --version 2>&1')
         cmd.stdout.strip
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT, Mixlib::ShellOut::ShellCommandFailed
         nil
       end
     end


### PR DESCRIPTION
On CentOS 7 `ntpd --version` is outputting:

```
ntpd 4.2.6p5

exit 0
```

However, the first line, with the version number is being outputted to STDERR and thus wasn't being captured.  This caused the Regexp.last_match to be empty which of course failed the cookbook.  This ensures everything is captured.
