### PR TITLE
Fix TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 NTP Cookbook
 ============
-[![Build Status](https://secure.travis-ci.org/opscode-cookbooks/ntp.png?branch=master)](http://travis-ci.org/opscode-cookbooks/ntp)
+[![Build Status](https://secure.travis-ci.org/gmiranda23/ntp.png?branch=master)](http://travis-ci.org/gmiranda23/ntp)
 
 Installs and configures ntp. On Windows systems it uses the Meinberg port of the standard NTPd client to Windows.
 


### PR DESCRIPTION
This commit fixes the badge in the readme, but I think you'll still have to set up the webhook in the github repo.
