### PR TITLE
add ability to ignore interfaces

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default['ntp']['leapfile'] = '/etc/ntp.leapseconds'
 default['ntp']['sync_clock'] = false
 default['ntp']['sync_hw_clock'] = false
 default['ntp']['listen'] = nil
+default['ntp']['ignore'] = nil
 default['ntp']['listen_network'] = nil
 default['ntp']['apparmor_enabled'] = false
 default['ntp']['monitor'] = false

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -18,6 +18,14 @@ filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 
+
+<%# If the ignore attribute is set on the node, then apply it %>
+<% unless node['ntp']['ignore'].nil? -%>
+<%   Array(node['ntp']['ignore']).each do |ignore| -%>
+interface ignore <%= ignore %>
+<%   end -%>
+<% end -%>
+
 <%# If the listen attribute is set on the node, then apply it %>
 <% unless node['ntp']['listen'].nil? -%>
 interface listen <%= node['ntp']['listen'] %>


### PR DESCRIPTION
Sometimes we need to ignore specific interfaces for listening.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
