### PR TITLE
Fix appamor configuration for Ubuntu

### DIFF
--- a/files/default/usr.sbin.ntpd.apparmor
+++ b/files/default/usr.sbin.ntpd.apparmor
@@ -39,6 +39,8 @@
   @{PROC}/*/net/if_inet6 r,
   @{NTPD_DEVICE} rw,
 
+  /{,s}bin/      r,
+  /usr/{,s}bin/  r,
   /usr/sbin/ntpd rmix,
 
   /etc/ntp.conf r,


### PR DESCRIPTION
Since at least Ubuntu 14.04, I saw lot of errors in syslog :

```
[4542988.686845] type=1400 audit(1416405833.983:2260): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/usr/local/sbin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[4542988.686856] type=1400 audit(1416405833.983:2261): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/usr/local/bin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[4542988.686863] type=1400 audit(1416405833.983:2262): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/usr/sbin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[4542988.686869] type=1400 audit(1416405833.983:2263): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/usr/bin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[4542988.686875] type=1400 audit(1416405833.983:2264): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/sbin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[4542988.686882] type=1400 audit(1416405833.983:2265): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/bin/" pid=11667 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

After comparing the apparmor configuration from Ubuntu and the one in the ntp cookbook, I saw that two rules are missing.
