### PR TITLE
Fix berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://api.berkshelf.com"
+site :opscode
 metadata
 
 group :integration do


### PR DESCRIPTION
The Berksfile syntax used is for version 3, however the Gemfile is locked to version 2.0

Fixes issue https://github.com/gmiranda23/ntp/issues/78
