### PR TITLE
Update to berkself3

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://api.berkshelf.com"
+source 'https://api.berkshelf.com'
 metadata
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 2.0'
+gem 'berkshelf',  '~> 3.2.1'
 gem 'chefspec',   '~> 4.0'
 gem 'foodcritic', '~> 4.0'
 gem 'rubocop',    '~> 0.27.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,13 +2,5 @@ require 'chefspec'
 require 'berkshelf'
 
 Berkshelf.ui.mute do
-  Berkshelf::Berksfile.from_file('Berksfile').install(path: 'vendor/cookbooks/')
-end
-
-RSpec.configure do |c|
-  c.after(:suite) do
-    # Berks will infinitely nest vendor/cookbooks/ntp on each rspec run
-    # https://github.com/RiotGames/berkshelf/issues/828
-    FileUtils.rm_rf('vendor/')
-  end
+  Berkshelf::Berksfile.from_file('Berksfile').install
 end


### PR DESCRIPTION
The Berksfile syntax used is for version 3, however the Gemfile is locked to version 2.0
The spec_helper also needed updating for the new Berkshelf syntax.

Fixes issue #78 
