### PR TITLE
Fix resource cloning warning in recipe[default]

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,8 @@ else
     package ntppkg
   end
 
-  package 'ntpdate' do
+  package 'Remove ntpdate' do
+    package_name 'ntpdate'
     action :remove
     only_if { node['platform_family'] == 'debian' && node['platform_version'].to_i >= 16 }
   end


### PR DESCRIPTION
### Description

This PR fixes the following cloned resource warning:

```
==> master: Deprecated features used!
==> master:   Cloning resource attributes for yum_package[ntpdate] from prior resource (CHEF-3694)
==> master: Previous yum_package[ntpdate]: /tmp/vagrant-cache/chef/cookbooks/ntp/recipes/default.rb:33:in `block in from_file'
==> master: Current  yum_package[ntpdate]: /tmp/vagrant-cache/chef/cookbooks/ntp/recipes/default.rb:36:in `from_file' at 1 location:
==> master:     - /tmp/vagrant-cache/chef/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
==> master: 
```

The problem happens because:
 - the `node['ntp']['packages']` attribute includes a 'ntpdate' package (at least on centos 7.2)
 - 3 lines below, there is a `package 'ntpdate' { action: remove }` which applies to some distributions

Solution: rename the `package 'ntpdate' { action: remove }` resource while setting the package_name attribute to not trigger the warning.