### PR TITLE
Add default driftfile location for RHEL family

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,7 @@ when 'debian'
   default['ntp']['apparmor_enabled'] = true if File.exist? '/etc/init.d/apparmor'
 when 'rhel', 'fedora'
   default['ntp']['packages'] = %w(ntp ntpdate) if node['platform_version'].to_i >= 7
+  default['ntp']['driftfile'] = "#{node['ntp']['varlibdir']}/drift"
 when 'windows'
   default['ntp']['service'] = 'NTP'
   default['ntp']['driftfile'] = 'C:\\NTP\\ntp.drift'


### PR DESCRIPTION
### Description

Switches the default driftfile location to the RHEL-family distro default location

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
