### PR TITLE
Fix installation and config on Solaris 10 & 11.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,14 @@ platforms:
   - name: windows-2012r2
     driver_config:
       box: chef/windows-server-2012r2-standard
+# Solaris 10 requires the release directory from the  OS ISO to be in `/var/spool/pkg`
+# in order for the converge to succeed.
+  - name: solaris-10.11
+    driver_config:
+      box: chef/solaris-10.11
+  - name: solaris-11.3
+    driver_config:
+      box: chef/solaris-11.3
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ These attributes are set based on platform / system information provided by Ohai
 - `ntp['packages']`
 
   - Array, the packages to install
-  - Default, ntp for everything, ntpdate depending on platform. Not applicable for
-  - Windows nodes
+  - Default, ntp for everything, ntpdate depending on platform. Not applicable for Windows nodes.
 
 - `ntp['service']`
 
@@ -232,6 +231,11 @@ These attributes are set based on platform / system information provided by Ohai
 
   - Boolean, uses a high stratum undisciplined clock for machines with real CMOS clock.
   - Defaults to true unless a platform appears to be virtualized according to Ohai.
+
+- `ntp['pkg_source']`
+  - _Only applicable to Solaris 10_
+  - String, device/path to Solaris packages.
+  - Defaults to `/var/spool/pkg`
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,6 +108,10 @@ when 'freebsd'
 when 'gentoo'
   default['ntp']['leapfile'] = "#{node['ntp']['varlibdir']}/ntp.leapseconds"
 when 'solaris2'
+  if node['platform_version'] < '5.11'
+    default['ntp']['packages'] = %w(SUNWntpu SUNWntpr)
+    default['ntp']['pkg_source'] = '/var/spool/pkg'
+  end
   default['ntp']['service'] = 'ntp'
   default['ntp']['varlibdir'] = '/var/ntp'
   default['ntp']['conffile'] = '/etc/inet/ntp.conf'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,10 @@ when 'mac_os_x'
 else
 
   node['ntp']['packages'].each do |ntppkg|
-    package ntppkg
+    package ntppkg do
+      source node['ntp']['pkg_source'] if platform_family?('solaris2') && node['platform_version'] < '5.11'
+      action :install
+    end
   end
 
   package 'Remove ntpdate' do
@@ -108,7 +111,14 @@ if node['ntp']['sync_clock'] && !platform_family?('windows')
   end
 
   execute 'Force sync system clock with ntp server' do
-    command node['platform_family'] == 'freebsd' ? 'ntpd -q' : "ntpd -q -u #{node['ntp']['var_owner']}"
+    command case node['platform_family']
+            when 'freebsd'
+              'ntpd -q'
+            when 'solaris2', 'aix'
+              "ntpdate #{node['ntp']['servers'].sample}"
+            else
+              "ntpd -q -u #{node['ntp']['var_owner']}"
+            end
     action :run
     notifies :start, "service[#{node['ntp']['service']}]"
   end
@@ -117,7 +127,7 @@ end
 execute 'Force sync hardware clock with system clock' do
   command 'hwclock --systohc'
   action :run
-  only_if { node['ntp']['sync_hw_clock'] && !(platform_family?('windows') || platform_family?('freebsd')) }
+  only_if { node['ntp']['sync_hw_clock'] && !platform_family?('windows', 'solaris2', 'freebsd') }
 end
 
 service node['ntp']['service'] do


### PR DESCRIPTION
### Description

This fixes installation and service configuration on Solaris 10 and 11. Note, Solaris 10 requires the packages to be available from a local path/device in order to install them.

### Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin.