### PR TITLE
Set default service name on SLES 11.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,9 @@ platforms:
   - name: freebsd-11.0
     run_list: freebsd::portsnap
   - name: opensuse-leap-42.2
+  - name: sles-11.2
+    driver_config:
+      box: chef/sles-11-sp2-x86_64
   - name: ubuntu-14.04
     run_list: apt::default
   - name: ubuntu-16.04

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -127,6 +127,8 @@ when 'pld'
   default['ntp']['leapfile'] = '/etc/ntp/ntp.leapseconds'
   default['ntp']['driftfile'] = "#{node['ntp']['varlibdir']}/drift"
   default['ntp']['var_owner'] = 'root'
+when 'suse'
+  default['ntp']['service'] = 'ntp' if node['platform_version'].to_f < 12
 end
 
 unless node['platform'] == 'windows'


### PR DESCRIPTION
### Description

This sets the default service name on SLES 11.x to `ntp` rather than `ntpd` and adds the SLES 11 private bento box to the `.kitchen.yml` file.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
