### PR TITLE
Fix MacOS X default attributes and OSX chefspec.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,6 +39,15 @@ platforms:
   - name: solaris-11.3
     driver_config:
       box: chef/solaris-11.3
+  - name: macosx-10.10
+    driver_config:
+      box: chef/macosx-10.10
+  - name: macosx-10.11
+    driver_config:
+      box: chef/macosx-10.10
+  - name: macosx-10.12
+    driver_config:
+      box: chef/macosx-10.10
 
 suites:
   - name: default

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,16 @@
 
 ::Chef::Resource.send(:include, Opscode::Ntp::Helper)
 
+if node['ntp']['servers'].empty?
+  node.default['ntp']['servers'] = [
+    '0.pool.ntp.org',
+    '1.pool.ntp.org',
+    '2.pool.ntp.org',
+    '3.pool.ntp.org',
+  ]
+  Chef::Log.debug 'No NTP servers specified, using default ntp.org server pools'
+end
+
 case node['platform_family']
 when 'windows'
   include_recipe 'ntp::windows_client'
@@ -59,16 +69,6 @@ else
   end
 
   include_recipe 'ntp::apparmor' if node['ntp']['apparmor_enabled']
-end
-
-if node['ntp']['servers'].empty?
-  node.default['ntp']['servers'] = [
-    '0.pool.ntp.org',
-    '1.pool.ntp.org',
-    '2.pool.ntp.org',
-    '3.pool.ntp.org',
-  ]
-  Chef::Log.debug 'No NTP servers specified, using default ntp.org server pools'
 end
 
 if node['ntp']['listen'].nil? && !node['ntp']['listen_network'].nil?

--- a/recipes/mac_os_x_client.rb
+++ b/recipes/mac_os_x_client.rb
@@ -21,12 +21,12 @@
 return 'The ntp::mac_os_x_client recipe only supports Mac OS X' unless platform_family?('mac_os_x')
 
 # Mac OS X 10.11+ does not allow for many NTP settings
-execute 'systemsetup -setnetworktimeserver' do
+execute 'set_ntp_server' do
   command "systemsetup -setnetworktimeserver #{node['ntp']['servers'][0]}"
   not_if "systemsetup -getnetworktimeserver | grep -F #{node['ntp']['servers'][0]}"
 end
 
-execute 'systemsetup -setusingnetworktime' do
+execute 'enable_ntp' do
   command 'systemsetup -setusingnetworktime on'
   not_if 'systemsetup -getusingnetworktime | grep On'
 end

--- a/spec/unit/recipes/mac_os_x_client_spec.rb
+++ b/spec/unit/recipes/mac_os_x_client_spec.rb
@@ -1,18 +1,25 @@
 require 'spec_helper'
 
 describe 'ntp::mac_os_x_client' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.11.1').converge('ntp::mac_os_x_client') }
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'mac_os_x',
+      version: '10.12'
+    ) do |node|
+      node.normal['ntp']['servers'] = %w(one two three)
+    end.converge(described_recipe)
+  end
 
   before do
-    stub_command('systemsetup -getnetworktimeserver | grep -F ').and_return(false)
+    stub_command('systemsetup -getnetworktimeserver | grep -F one').and_return(false)
     stub_command('systemsetup -getusingnetworktime | grep On').and_return(false)
   end
 
   it 'executes systemsetup -setnetworktimeserver' do
-    expect(chef_run).to run_execute('systemsetup -setnetworktimeserver')
+    expect(chef_run).to run_execute('set_ntp_server').with_command('systemsetup -setnetworktimeserver one')
   end
 
   it 'executes systemsetup -setusingnetworktime on' do
-    expect(chef_run).to run_execute('systemsetup -setusingnetworktime')
+    expect(chef_run).to run_execute('enable_ntp').with_command('systemsetup -setusingnetworktime on')
   end
 end


### PR DESCRIPTION
### Description

This fixes the ChefSpec tests for MacOS X so that they properly test the commands exeucted on OSX. Additionally this fixes and order of operations issue on OSX by ensuring the servers attribute is set before we call the mac_os_x_client recipe which makes use of the attribute.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


/cc @chef-cookbooks/engineering-services 