### PR TITLE
Fix apparmor dgram denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the ntp cookbook.
 
+## 3.5.2 (2017-08-16)
+
+- Fix apprarmor denied for sock_type=dgram in ubuntu dists.
+
 ## 3.5.1 (2017-06-28)
 
 - Use the latest NTP release on windows to resolve several bugs

--- a/files/usr.sbin.ntpd.apparmor
+++ b/files/usr.sbin.ntpd.apparmor
@@ -30,6 +30,7 @@
   capability sys_time,
   capability sys_nice,
 
+  network dgram,
   network inet dgram,
   network inet6 dgram,
   network inet stream,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures ntp as a client or server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.5.1'
+version '3.5.2'
 
 recipe 'ntp', 'Installs and configures ntp either as a server or client'
 


### PR DESCRIPTION
### Description

Add rule for apparmor.

### Issues Resolved

I fixed bug in ubuntu 16.04 xenial. 

```
kernel: [510512.518585] audit: type=1400 audit(1502873744.476:2009): apparmor="DENIED" operation="create" profile="/usr/sbin/ntpd" pid=18273 comm="ntpd" family="unspec" sock_type="dgram" protocol=0 requested_mask="create" denied_mask="create"
```