### PR TITLE
Non-interactive install fails on Solaris10

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,8 +41,10 @@ else
 
   node['ntp']['packages'].each do |ntppkg|
     package ntppkg do
-      source node['ntp']['pkg_source'] if platform_family?('solaris2') && node['platform_version'] < '5.11'
+      source node['ntp']['pkg_source']
       action :install
+      # Non-interactive package install fails on Solaris10 so we need to manually the ntp package
+      not_if { node['platform_family'] == 'solaris2' && node['platform_version'].to_f <= 5.10 }
     end
   end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -348,4 +348,32 @@ restrict 0.pool.ntp.org nomodify notrap noquery'
       expect(chef_run).to enable_service('ntpd')
     end
   end
+
+  context 'solaris2' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'solaris2', version: '5.11').converge('ntp::default') }
+
+    it 'installs the ntp package' do
+      expect(chef_run).to install_package('ntp')
+    end
+
+    it 'does not install the ntpdate package' do
+      expect(chef_run).to_not install_package('ntpdate')
+    end
+
+    it 'starts the ntp service' do
+      expect(chef_run).to start_service('ntp')
+    end
+
+    it 'enables the ntp service' do
+      expect(chef_run).to enable_service('ntp')
+    end
+  end
+
+  context 'solaris2 version 5.10' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'solaris2', version: '5.10').converge('ntp::default') }
+
+    it 'does not install the ntp package' do
+      expect(chef_run).to_not install_package('ntp')
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Do not install ntp packages on Solaris10 as non-interactive install fails

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
