### PR TITLE
Add the attach_disconnected flag to the ntpd AppArmor config

### DIFF
--- a/files/usr.sbin.ntpd.apparmor
+++ b/files/usr.sbin.ntpd.apparmor
@@ -16,7 +16,7 @@
 
 #include <tunables/global>
 #include <tunables/ntpd>
-/usr/sbin/ntpd {
+/usr/sbin/ntpd flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/nameservice>
   #include <abstractions/user-tmp>

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -28,6 +28,14 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
+- name: debian-9
+  driver:
+    image: debian:9
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install systemd apt-transport-https lsb-release procps net-tools -y
+
 - name: centos-6
   driver:
     image: centos:6

--- a/spec/unit/recipes/apparmor_spec.rb
+++ b/spec/unit/recipes/apparmor_spec.rb
@@ -4,8 +4,11 @@ describe 'ntp::apparmor' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge('recipe[ntp::apparmor]') }
 
   it 'creates the apparmor file' do
-    expect(chef_run).to create_cookbook_file '/etc/apparmor.d/usr.sbin.ntpd'
-    file = chef_run.cookbook_file('/etc/apparmor.d/usr.sbin.ntpd')
+    cr = chef_run
+    expect(cr).to create_cookbook_file('/etc/apparmor.d/usr.sbin.ntpd')
+    expect(cr).to render_file('/etc/apparmor.d/usr.sbin.ntpd')
+      .with_content(%r{^/usr/sbin/ntpd flags=\(attach_disconnected\)})
+    file = cr.cookbook_file('/etc/apparmor.d/usr.sbin.ntpd')
     expect(file.owner).to eq('root')
     expect(file.group).to eq('root')
   end


### PR DESCRIPTION
### Description

I was running into an issue running with AppArmor blocking tests of this
cookbook inside Docker containers, which I wouldn't submit a patch for, but it
looks like this is in the config packaged with ntp as of Ubuntu 18.04 and will
be in Debian 10.

```
➜  ~ docker run -i -t ubuntu:18.04
...
root@cf01577a341e:/# apt-get update && apt-get -y install apparmor ntp
...
root@cf01577a341e:/# grep ^\/ /etc/apparmor.d/usr.sbin.ntpd
/usr/sbin/ntpd flags=(attach_disconnected) {
```

See also https://bugs.launchpad.net/ubuntu/+source/ntp/+bug/1727202.

Signed-off-by: Jonathan Hartman <j@hartman.io>

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
