### PR TITLE
fix: apparmor warnings

### DIFF
--- a/files/usr.sbin.ntpd.apparmor
+++ b/files/usr.sbin.ntpd.apparmor
@@ -76,6 +76,7 @@
 
   /{,var/}run/ntpd.pid w,
   /{,var/}run/ntp.conf.dhcp r,
+  /{,var/}run/systemd/journal/dev-log rw,
 
   # samba4 ntp signing socket
   /{,var/}run/samba/ntp_signd/socket rw,

--- a/files/usr.sbin.ntpd.apparmor
+++ b/files/usr.sbin.ntpd.apparmor
@@ -75,6 +75,7 @@
   /var/log/ntpstats/sysstats*   rwl,
 
   /{,var/}run/ntpd.pid w,
+  /{,var/}run/ntp.conf.dhcp r,
 
   # samba4 ntp signing socket
   /{,var/}run/samba/ntp_signd/socket rw,

--- a/spec/unit/recipes/apparmor_spec.rb
+++ b/spec/unit/recipes/apparmor_spec.rb
@@ -8,6 +8,8 @@ describe 'ntp::apparmor' do
     expect(cr).to create_cookbook_file('/etc/apparmor.d/usr.sbin.ntpd')
     expect(cr).to render_file('/etc/apparmor.d/usr.sbin.ntpd')
       .with_content(%r{^/usr/sbin/ntpd flags=\(attach_disconnected\)})
+    expect(cr).to render_file('/etc/apparmor.d/usr.sbin.ntpd')
+      .with_content(/ntp.conf.dhcp r/)
     file = cr.cookbook_file('/etc/apparmor.d/usr.sbin.ntpd')
     expect(file.owner).to eq('root')
     expect(file.group).to eq('root')


### PR DESCRIPTION
### Description

fix some apparmor errors:

```
Jan 28 13:04:13 hostname kernel: [4561051.223255] audit: type=1400 audit(1548680653.668:2020): apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd" name="/run/ntp.conf.dhcp" pid=6635 comm="ntpd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

```
Feb  4 11:55:05 hostname kernel: [1468644.987367] audit: type=1400 audit(1549281305.745:616): apparmor="DENIED" operation="sendmsg" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="run/systemd/journal/dev-log" pid=28123 comm="ntpd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

### Issues Resolved

no issues opened

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>