### PR TITLE
Use ntpsec user/group for Ubuntu >= 23.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the ntp cookbook.
 
 ## Unreleased
 
+Since ubuntu 23.10[Mantic Minotaur] the ntp user is ntpsec
+
 ## 5.2.2 - *2024-07-15*
 
 Update ntpd package for Enterprise Linux 9 (ie Oracle, Rocky, Alma)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,9 @@ default['ntp']['conf_group'] = 'root'
 if platform?('debian') && node['platform_version'].to_i >= 12
   default['ntp']['var_owner'] = 'ntpsec'
   default['ntp']['var_group'] = 'ntpsec'
+elsif platform?('ubuntu') && Gem::Version.new(node['platform_version']) >= Gem::Version.new('23.10')
+  default['ntp']['var_owner'] = 'ntpsec'
+  default['ntp']['var_group'] = 'ntpsec'
 else
   default['ntp']['var_owner'] = 'ntp'
   default['ntp']['var_group'] = 'ntp'

--- a/files/usr.sbin.ntpd.apparmor
+++ b/files/usr.sbin.ntpd.apparmor
@@ -58,6 +58,8 @@
   /etc/ntp.keys r,
   /etc/ntp/** r,
 
+  /etc/ntpsec/** r,
+
   /etc/ntp.drift rwl,
   /etc/ntp.drift.TEMP rwl,
   /etc/ntp/drift* rwl,

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -210,7 +210,7 @@ describe 'ntp attributes' do
   end
 
   describe 'on Ubuntu >= 23.10' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '23.10').converge('ntp::default') }
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '24.04').converge('ntp::default') }
 
     it 'sets the var_owner to ntpsec' do
       expect(ntp['var_owner']).to eq('ntpsec')

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -209,6 +209,18 @@ describe 'ntp attributes' do
     end
   end
 
+  describe 'on Ubuntu >= 23.10' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '23.10').converge('ntp::default') }
+
+    it 'sets the var_owner to ntpsec' do
+      expect(ntp['var_owner']).to eq('ntpsec')
+    end
+
+    it 'sets the var_group to ntpsec' do
+      expect(ntp['var_group']).to eq('ntpsec')
+    end
+  end
+
   describe 'on the CentOS 7 platform' do
     cached(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7').converge('ntp::default') }
 


### PR DESCRIPTION
# Description

Ubuntu is also using ntpsec from verson 23.10 onward.
This PR is a proposal to get aligned with this change.
https://packages.ubuntu.com/mantic/ntp
https://wiki.ubuntu.com/JonathanFerguson/NTP

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

Sorry don't know how to fix the test problem, no platform above the 22.04 listed here: https://github.com/chef/fauxhai/blob/main/PLATFORMS.md

Also will add the docs and changelogs if the changes are ok from your side

