### PR TITLE
fix: migrate to Policyfile and clean up docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb                   # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'ntp'
+
+run_list 'test::default'
+
+cookbook 'ntp', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/documentation/ntp_ntp_service.md
+++ b/documentation/ntp_ntp_service.md
@@ -6,7 +6,7 @@ packaged config file, and manages the packaged systemd service.
 ## Actions
 
 | Action | Description |
-|---|---|
+| --- | --- |
 | `:create` | Installs and configures the platform NTP service and starts it (default) |
 | `:start` | Starts the platform NTP service |
 | `:stop` | Stops the platform NTP service |
@@ -16,7 +16,7 @@ packaged config file, and manages the packaged systemd service.
 ## Properties
 
 | Property | Type | Default | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `instance_name` | String | `name property` | Resource instance name |
 | `package_name` | String | platform default | Main package to install |
 | `sync_package_name` | `String`, `nil` | platform default | Optional package used for `sync_clock` when the platform requires one |


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile.rb
- switch ChefSpec setup to Policyfile support where applicable
- update Copilot setup/docs away from berks install
- keep Policyfile.lock.json generated locally and ignored

## Verification
- chef install Policyfile.rb
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- chef exec rspec --format documentation equivalent via Workstation embedded RSpec
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-debian-12 --destroy=always